### PR TITLE
Add TLS support by default

### DIFF
--- a/matomo/templates/ingress-matomo-dashboard.yaml
+++ b/matomo/templates/ingress-matomo-dashboard.yaml
@@ -15,3 +15,8 @@ spec:
           serviceName: matomo-dashboard
           servicePort: 8080
         path: /
+  {{- if .Values.matomo.dashboard.tls }}      
+  tls:
+  - hosts:
+    - {{.Values.matomo.dashboard.hostname}}
+  {{- end -}}

--- a/matomo/templates/ingress-matomo-tracker.yaml
+++ b/matomo/templates/ingress-matomo-tracker.yaml
@@ -19,3 +19,8 @@ spec:
           serviceName: matomo-tracker
           servicePort: 8080
         path: /piwik.js
+  {{- if .Values.matomo.tracker.tls }}      
+  tls:
+  - hosts:
+    - {{.Values.matomo.tracker.hostname}}
+  {{- end -}}

--- a/matomo/values.yaml
+++ b/matomo/values.yaml
@@ -104,12 +104,14 @@ matomo:
       username: admin
       password: admin123
       email: foo@example.com
+    tls: true
   queuedTrackingProcess:
     replicas: 1
   tracker:
     replicas: 1
     hostname: localhost
     port: 8080
+    tls: true
 nginx:
   image: registry.wklive.net:5000/digitalist/nginx:1.15.8-alpine-master-f152f040580cd163d7cdf4138d8ca897e63282c6
   runAsUser: 100


### PR DESCRIPTION
Adds TLS support and enable it by default. This PR enables the default snake oil certificate for the hostnames for both the Dashboard and Tracker.

Specifically for arbetsförmedlingen, we use http and https on port 32080 and 32443. Baffin Bay uses the ingresses as origin servers and it uses TLS for this, so port 32443 is used. Therefore, this is set as default.