### PR TITLE
docs: document ingress TLS secret names

### DIFF
--- a/charts/matomo/README.md
+++ b/charts/matomo/README.md
@@ -66,6 +66,7 @@ A Helm chart for Matomo
 | matomo.dashboard.nginx.readinessProbe.initialDelaySeconds | int | `10` |  |
 | matomo.dashboard.nginx.readinessProbe.periodSeconds | int | `5` |  |
 | matomo.dashboard.replicas | int | `1` |  |
+| matomo.dashboard.secretName | string | `""` | Existing TLS secret name for the dashboard ingress. |
 | matomo.dashboard.sidecars | list | `[]` |  |
 | matomo.dashboard.tls | bool | `false` |  |
 | matomo.env | list | `[]` | Env variables to inject, if any. |
@@ -109,6 +110,7 @@ A Helm chart for Matomo
 | matomo.tracker.phpfpm.process_idle_timeout | string | `"600s"` |  |
 | matomo.tracker.phpfpm.type | string | `"ondemand"` |  |
 | matomo.tracker.replicas | int | `1` |  |
+| matomo.tracker.secretName | string | `""` | Existing TLS secret name for the tracker ingress. |
 | matomo.tracker.tls | bool | `false` |  |
 | namespace | string | `"matomo"` | Namespace to install Matomo in, default matomo. |
 | nginx.image | string | `"digitalist/nginx:1.21.6"` |  |

--- a/charts/matomo/values.yaml
+++ b/charts/matomo/values.yaml
@@ -111,6 +111,8 @@ matomo:
     loadbalancer: false
     hostname: my.host
     tls: false
+    # -- Existing TLS secret name for the dashboard ingress.
+    secretName: ""
     firstuser:
       username: admin
       password: admin123
@@ -163,6 +165,8 @@ matomo:
     replicas: 1
     hostname: my.host
     tls: false
+    # -- Existing TLS secret name for the tracker ingress.
+    secretName: ""
     loadbalancer: false
     nginx:
       resources:


### PR DESCRIPTION
## Summary

Closes #67.

Adds the existing `matomo.dashboard.secretName` and `matomo.tracker.secretName` values to the chart defaults and generated values table.

The ingress templates already read both values when TLS is enabled, but they were not exposed in `values.yaml` or documented in the README. Setting them explicitly lets Traefik and Let's Encrypt users point each ingress at an existing TLS secret without relying on an undocumented chart value.

## Checks

- `git diff --check`
- parsed `charts/matomo/values.yaml` and verified both `secretName` defaults are present
