### PR TITLE
Make post-install and pre-upgrade jobs work without pre-existing matomo-startup-config ConfigMap

### DIFF
--- a/charts/matomo/README.md
+++ b/charts/matomo/README.md
@@ -12,6 +12,7 @@ A Helm chart for Matomo
 | db.name | string | `"matomo"` | Database name. |
 | db.password.secretKeyRef.key | string | `"mysql-root-password"` | Key within the secret holding the database password. |
 | db.password.secretKeyRef.name | string | `"matomo-db-mysql"` | Name of the secret holding the database password. |
+| db.port | int | `3306` | Database port. |
 | db.prefix | string | `"matomo_"` | Table prefix. |
 | db.username | string | `"root"` | Database username. |
 | extraConfigMaps | object | `{"create":false,"data":{}}` | Extra configMaps |

--- a/charts/matomo/templates/_helpers.tpl
+++ b/charts/matomo/templates/_helpers.tpl
@@ -39,57 +39,102 @@ imagePullSecrets:
       key: {{ .Values.matomo.license.secretKeyRef.key }}
 {{- end -}}
 {{- end -}}
+{{- define "matomo.initContainer" -}}
+- name: matomo-init
+  image: {{.Values.matomo.image}}
+  securityContext:
+    runAsUser: {{.Values.matomo.runAsUser}}
+    privileged: false
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+  imagePullPolicy: Always
+  env:
+  - name: MATOMO_FIRST_USER_NAME
+    value: {{.Values.matomo.dashboard.firstuser.username}}
+  - name: MATOMO_FIRST_USER_EMAIL
+    value: {{.Values.matomo.dashboard.firstuser.email}}
+  - name: MATOMO_FIRST_USER_PASSWORD
+    value: {{.Values.matomo.dashboard.firstuser.password}}
+  - name: MATOMO_DB_HOST
+    value: {{.Values.db.hostname}}
+  - name: MATOMO_DB_NAME
+    value: {{.Values.db.name}}
+{{- if .Values.db.prefix }}
+  - name: MATOMO_DB_PREFIX
+    value: {{.Values.db.prefix}}
+{{- end }}
+  - name: MATOMO_DB_USERNAME
+    value: {{.Values.db.username}}
+  - name: MATOMO_DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.db.password.secretKeyRef.name }}
+        key: {{ .Values.db.password.secretKeyRef.key }}
+{{- include "matomo.license" . | nindent 2 }}
+  command: [ 'sh' , '-c' , 'rsync -crlOt --no-owner --no-group --no-perms /usr/src/matomo/ /var/www/html/ && {{.Values.matomo.installCommand}}' ]
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  volumeMounts:
+    - name: static-data
+      mountPath: /var/www/html
+    - name: matomo-configuration
+      mountPath: /tmp/matomo/
+      readOnly: true
+{{- end -}}
+
 {{- define "matomo.init" -}}
 initContainers:
-  - name: matomo-init
-    image: {{.Values.matomo.image}}
-    securityContext:
-      runAsUser: {{.Values.matomo.runAsUser}}
-      privileged: false
-      allowPrivilegeEscalation: false
-      runAsNonRoot: true
-      capabilities:
-        drop:
-          - ALL
-    imagePullPolicy: Always
-    env:
-    - name: MATOMO_FIRST_USER_NAME
-      value: {{.Values.matomo.dashboard.firstuser.username}}
-    - name: MATOMO_FIRST_USER_EMAIL
-      value: {{.Values.matomo.dashboard.firstuser.email}}
-    - name: MATOMO_FIRST_USER_PASSWORD
-      value: {{.Values.matomo.dashboard.firstuser.password}}
-    - name: MATOMO_DB_HOST
-      value: {{.Values.db.hostname}}
-    - name: MATOMO_DB_NAME
-      value: {{.Values.db.name}}
-{{ if .Values.db.prefix }}
-    - name: MATOMO_DB_PREFIX
-      value: {{.Values.db.prefix}}
-{{- end }}
-    - name: MATOMO_DB_USERNAME
-      value: {{.Values.db.username}}
-    - name: MATOMO_DB_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.db.password.secretKeyRef.name }}
-          key: {{ .Values.db.password.secretKeyRef.key }}
-{{- include "matomo.license" . | nindent 4 }}
-    command: [ 'sh' , '-c' , 'rsync -crlOt --no-owner --no-group --no-perms /usr/src/matomo/ /var/www/html/ && {{.Values.matomo.installCommand}}' ]
-    resources:
-      limits:
-        cpu: 200m
-        memory: 512Mi
-      requests:
-        cpu: 100m
-        memory: 128Mi
-    volumeMounts:
-      - name: static-data
-        mountPath: /var/www/html
-      - name: matomo-configuration
-        mountPath: /tmp/matomo/
-        readOnly: true
+  {{- include "matomo.initContainer" . | nindent 2 }}
+{{- end -}}
 
+{{/*
+matomo-init fails fast when the database is unreachable, so a Job would burn
+its backoff retries while a fresh database is still provisioning. Bounded so
+an unreachable database fails the Job instead of hanging it forever.
+*/}}
+{{- define "matomo.waitForDb" -}}
+- name: wait-for-db
+  image: {{.Values.matomo.image}}
+  securityContext:
+    runAsUser: {{.Values.matomo.runAsUser}}
+    privileged: false
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+  imagePullPolicy: Always
+  command:
+    - bash
+    - -c
+    - |
+      host={{.Values.db.hostname}}
+      port={{.Values.db.port | default 3306}}
+      for i in $(seq 1 180); do
+        if (echo > /dev/tcp/$host/$port) 2>/dev/null; then
+          echo "database $host:$port is reachable"
+          exit 0
+        fi
+        echo "waiting for database $host:$port ($i/180)"
+        sleep 5
+      done
+      echo "database $host:$port not reachable after 15 minutes, giving up"
+      exit 1
+  resources:
+    limits:
+      cpu: 100m
+      memory: 64Mi
+    requests:
+      cpu: 10m
+      memory: 16Mi
 {{- end -}}
 
 {{/*

--- a/charts/matomo/templates/post-install-job.yaml
+++ b/charts/matomo/templates/post-install-job.yaml
@@ -29,6 +29,11 @@ spec:
           type: RuntimeDefault
       restartPolicy: Never
 {{ include "matomo.images.pullSecrets" ( dict "images" (list .Values.matomo) "global" .Values.global) | nindent 6 }}
+      # Self-provision config.ini.php the same way regular pods do, instead of
+      # depending on an externally supplied config.
+      initContainers:
+{{ include "matomo.waitForDb" . | nindent 8 }}
+{{ include "matomo.initContainer" . | nindent 8 }}
       containers:
       - name: post-install-matomo
         image: {{.Values.matomo.image}}
@@ -48,47 +53,20 @@ spec:
           capabilities:
             drop:
               - ALL
-        lifecycle:
-          postStart:
-            exec:
-              command: [ 'sh' , '-c' , '{{.Values.matomo.installCommand}}' ]
         # To do anything with Matomo, we first need to bootstrap it (curl).
         command:  [ 'bash' , '-c' , 'sleep {{.Values.matomo.postInstallSleepTime}}; curl -Il --max-time 10 https://{{.Values.matomo.dashboard.hostname}}; {{.Values.matomo.postInstallCommand}}' ]
-        env:
-        - name: MATOMO_FIRST_USER_NAME
-          value: {{.Values.matomo.dashboard.firstuser.username}}
-        - name: MATOMO_FIRST_USER_EMAIL
-          value: {{.Values.matomo.dashboard.firstuser.email}}
-        - name: MATOMO_FIRST_USER_PASSWORD
-          value: {{.Values.matomo.dashboard.firstuser.password}}
-        - name: MATOMO_DB_HOST
-          value: {{.Values.db.hostname}}
-        - name: MATOMO_DB_NAME
-          value: {{.Values.db.name}}
-        {{ if .Values.db.prefix }}
-        - name: MATOMO_DB_PREFIX
-          value: {{.Values.db.prefix}}
-        {{ end }}
-        - name: MATOMO_DB_USERNAME
-          value: {{.Values.db.username}}
-        - name: MATOMO_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.db.password.secretKeyRef.name }}
-              key: {{ .Values.db.password.secretKeyRef.key }}
-{{ include "matomo.license" . | nindent 8 }}
         volumeMounts:
-        - name: matomo-startup-config
-          mountPath: /var/www/html/config/config.ini.php
-          subPath: config.ini.php
+        - name: static-data
+          mountPath: /var/www/html
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
       volumes:
-        - name: matomo-startup-config
+        - name: matomo-configuration
           configMap:
-            name: matomo-startup-config
-            optional: true
+            name: matomo-configuration
+        - name: static-data
+          emptyDir: {}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}
 {{- end }}

--- a/charts/matomo/templates/pre-upgrade-job.yaml
+++ b/charts/matomo/templates/pre-upgrade-job.yaml
@@ -29,6 +29,14 @@ spec:
           type: RuntimeDefault
       restartPolicy: Never
 {{ include "matomo.images.pullSecrets" ( dict "images" (list .Values.matomo) "global" .Values.global) | nindent 6 }}
+      # Under plain helm this hook runs before release resources are updated, so
+      # it sees the previous release's matomo-configuration and never runs on
+      # install. The init containers make the Job self-sufficient, so it also
+      # works when tools like ArgoCD run it as a sync hook on a fresh namespace
+      # where the database is still provisioning.
+      initContainers:
+{{ include "matomo.waitForDb" . | nindent 8 }}
+{{ include "matomo.initContainer" . | nindent 8 }}
       containers:
       - name: pre-upgrade-matomo
         image: {{.Values.matomo.image}}
@@ -49,41 +57,19 @@ spec:
             drop:
               - ALL
         volumeMounts:
-        - name: matomo-startup-config
-          mountPath: /var/www/html/config/config.ini.php
-          subPath: config.ini.php
+        - name: static-data
+          mountPath: /var/www/html
         - name: matomo-pre-upgrade-additional-config-maps
           mountPath: /var/www/html/config/common.config.ini.php
           subPath: common.config.ini.php
         # To do anything with Matomo, we first need to bootstrap it (curl).
         command:  [ 'bash' , '-c' , 'sleep {{.Values.matomo.preUpgradeSleepTime}}; curl -Il --max-time 10 https://{{.Values.matomo.dashboard.hostname}}; {{.Values.matomo.preUpgradeCommand}}' ]
-        env:
-        - name: MATOMO_FIRST_USER_NAME
-          value: {{.Values.matomo.dashboard.firstuser.username}}
-        - name: MATOMO_FIRST_USER_EMAIL
-          value: {{.Values.matomo.dashboard.firstuser.email}}
-        - name: MATOMO_FIRST_USER_PASSWORD
-          value: {{.Values.matomo.dashboard.firstuser.password}}
-        - name: MATOMO_DB_HOST
-          value: {{.Values.db.hostname}}
-        - name: MATOMO_DB_NAME
-          value: {{.Values.db.name}}
-        {{ if .Values.db.prefix }}
-        - name: MATOMO_DB_PREFIX
-          value: {{.Values.db.prefix}}
-        {{ end }}
-        - name: MATOMO_DB_USERNAME
-          value: {{.Values.db.username}}
-        - name: MATOMO_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.db.password.secretKeyRef.name }}
-              key: {{ .Values.db.password.secretKeyRef.key }}
-{{ include "matomo.license" . | nindent 8 }}
       volumes:
-        - name: matomo-startup-config
+        - name: matomo-configuration
           configMap:
-            name: matomo-startup-config
+            name: matomo-configuration
+        - name: static-data
+          emptyDir: {}
 {{ if  .Values.extraConfigMaps.create }}
         - name: matomo-pre-upgrade-additional-config-maps
           configMap:

--- a/charts/matomo/values.schema.json
+++ b/charts/matomo/values.schema.json
@@ -45,6 +45,12 @@
           "title": "password",
           "type": "object"
         },
+        "port": {
+          "default": "3306",
+          "description": "Database port.",
+          "required": [],
+          "title": "port"
+        },
         "prefix": {
           "default": "matomo_",
           "description": "Table prefix.",

--- a/charts/matomo/values.yaml
+++ b/charts/matomo/values.yaml
@@ -493,6 +493,8 @@ nginx:
 db:
   # -- Database hostname.
   hostname: matomo-db-mysql
+  # -- Database port.
+  port: 3306
   password:
     secretKeyRef:
       # -- Name of the secret holding the database password.


### PR DESCRIPTION
[The following description is LLM generated. I reviewed and iterated on it carefully to remove superfluous jargon and have it focus on important information]

Both hook jobs mounted `config.ini.php` from a `matomo-startup-config` ConfigMap that this chart never defines. The jobs therefore only work if an operator creates it by hand; without it, the pre-upgrade pod cannot even schedule.

This PR removes that second config path: the jobs now bootstrap Matomo the same way every other pod in the chart does.

- `matomo-init`, extracted from the `matomo.init` helper for reuse, regenerates `config.ini.php` from the chart's own `matomo-configuration` ConfigMap. Existing deployments and cronjobs render unchanged.
- `matomo-init` fails fast when the database is unreachable — a Deployment absorbs this by restarting, but a Job burns its limited retries. A new `wait-for-db` init container therefore waits for the database first, capped at 15 minutes.