### PR TITLE
Make the hook jobs succeed reliably when the dashboard is not deployed yet

### DIFF
--- a/charts/matomo/templates/post-install-job.yaml
+++ b/charts/matomo/templates/post-install-job.yaml
@@ -33,7 +33,7 @@ spec:
             exec:
               command: [ 'sh' , '-c' , '{{.Values.matomo.installCommand}}' ]
         # To do anything with Matomo, we first need to bootstrap it (curl).
-        command:  [ 'bash' , '-c' , 'sleep {{.Values.matomo.postInstallSleepTime}}; curl -Il https://{{.Values.matomo.dashboard.hostname}}; {{.Values.matomo.postInstallCommand}}' ]
+        command:  [ 'bash' , '-c' , 'sleep {{.Values.matomo.postInstallSleepTime}}; curl -Il --max-time 10 https://{{.Values.matomo.dashboard.hostname}}; {{.Values.matomo.postInstallCommand}}' ]
         env:
         - name: MATOMO_FIRST_USER_NAME
           value: {{.Values.matomo.dashboard.firstuser.username}}

--- a/charts/matomo/templates/pre-upgrade-job.yaml
+++ b/charts/matomo/templates/pre-upgrade-job.yaml
@@ -36,7 +36,7 @@ spec:
           mountPath: /var/www/html/config/common.config.ini.php
           subPath: common.config.ini.php
         # To do anything with Matomo, we first need to bootstrap it (curl).
-        command:  [ 'bash' , '-c' , 'sleep {{.Values.matomo.preUpgradeSleepTime}}; curl -Il https://{{.Values.matomo.dashboard.hostname}}; {{.Values.matomo.preUpgradeCommand}}' ]
+        command:  [ 'bash' , '-c' , 'sleep {{.Values.matomo.preUpgradeSleepTime}}; curl -Il --max-time 10 https://{{.Values.matomo.dashboard.hostname}}; {{.Values.matomo.preUpgradeCommand}}' ]
         env:
         - name: MATOMO_FIRST_USER_NAME
           value: {{.Values.matomo.dashboard.firstuser.username}}


### PR DESCRIPTION
[The following description is LLM generated. I reviewed and iterated on it carefully to remove superfluous jargon and have it focus on important information]

The post-install and pre-upgrade jobs are meant to work without a reachable dashboard. Their curl against the dashboard hostname is only a bootstrap warm-up; its result is deliberately ignored.

The missing timeout breaks that intent. When the host accepts connections but never responds — typical for a half-deployed environment — the curl stalls forever. The Job then hangs before ever reaching its actual command, and a fresh install or upgrade never completes.

This PR adds --max-time 10 to both invocations. An absent dashboard now costs the Job at most ten seconds instead of blocking it permanently.